### PR TITLE
Prevent loss of all admins: ticket #28

### DIFF
--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using TabloidMVC.Models.ViewModels;
 using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
@@ -14,10 +15,13 @@ namespace TabloidMVC.Controllers
         // GET: UserProfileController
 
         private readonly UserProfileRepository _UserProfileRepository;
+        private readonly UserTypeRepository _UserTypeRepository;
 
         public UserProfileController(IConfiguration config)
         {
             _UserProfileRepository = new UserProfileRepository(config);
+            _UserTypeRepository = new UserTypeRepository(config);
+
         }
         public ActionResult Index()
         {
@@ -61,13 +65,17 @@ namespace TabloidMVC.Controllers
         // GET: UserProfileController/Edit/5
         public ActionResult Edit(int id)
         {
-            return View();
+            UPEditViewModel vm = new UPEditViewModel();
+            vm.UserTypes = _UserTypeRepository.GetAllUserTypes();
+            vm.UserProfile = _UserProfileRepository.GetUserById(id);
+
+            return View(vm);
         }
 
         // POST: UserProfileController/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Edit(int id, IFormCollection collection)
+        public ActionResult Edit(int id, UPEditViewModel vm)
         {
             try
             {

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using TabloidMVC.Models;
+using TabloidMVC.Models.ViewModels;
 using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
@@ -15,10 +16,14 @@ namespace TabloidMVC.Controllers
         // GET: UserProfileController
 
         private readonly UserProfileRepository _UserProfileRepository;
+        private readonly UserTypeRepository _UserTypeRepository;
+
 
         public UserProfileController(IConfiguration config)
         {
             _UserProfileRepository = new UserProfileRepository(config);
+            _UserTypeRepository = new UserTypeRepository(config);
+
         }
         public ActionResult Index()
         {
@@ -62,21 +67,44 @@ namespace TabloidMVC.Controllers
         // GET: UserProfileController/Edit/5
         public ActionResult Edit(int id)
         {
-            return View();
+            var vm = new UPEditViewModel();
+            vm.UserProfile = _UserProfileRepository.GetUserById(id);
+            vm.UserTypes = _UserTypeRepository.GetAllUserTypes();
+
+
+            return View(vm);
         }
 
         // POST: UserProfileController/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Edit(int id, IFormCollection collection)
+        public ActionResult Edit(int id, UPEditViewModel vm)
         {
+            vm.UserProfile.Id = id;
+            List<UserProfile> userProfiles = _UserProfileRepository.GetAllUsers();
+            int totalAdmins = userProfiles.Where(up => up.UserTypeId == 2).Count();
+
             try
             {
-                return RedirectToAction(nameof(Index));
+                if (vm.UserProfile.UserTypeId == 1 && totalAdmins < 2)
+                {
+                    vm.UserTypes = _UserTypeRepository.GetAllUserTypes();
+
+                    ModelState.AddModelError("UserProfile.UserTypeId", "Assign another admin before changing the final Admin to author");
+                    return View(vm);
+                }
+                else
+                {
+                    _UserProfileRepository.ChangeUserType(vm.UserProfile);
+
+                    //return RedirectToAction("Index");
+                    return RedirectToAction("Index");
+                }
             }
             catch
             {
-                return View();
+                vm.UserTypes = _UserTypeRepository.GetAllUserTypes();
+                return View("Index");
             }
         }
 

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -112,13 +112,25 @@ namespace TabloidMVC.Controllers
         [ValidateAntiForgeryToken]
         public IActionResult DeactivateUser(int userId, UserProfile userProfile)
         {
+
             userId = userProfile.Id;
+            List<UserProfile> userProfiles = _UserProfileRepository.GetAllUsers();
+            int totalAdmins = userProfiles.Where(up => up.UserTypeId == 2).Count();
+
             try
             {
-                if (userProfile.Activated == true )
-                {
-                    _UserProfileRepository.DeactivateUser(userId);
 
+                if (userProfile.Activated == true)
+                {
+                    if (userProfile.UserTypeId == 2 && totalAdmins < 2)
+                    {
+                        ModelState.AddModelError("UserTypeId", "Make someone else an admin before this User Profile can be deactivated");
+                        return View();
+                    }
+                    else
+                    {
+                        _UserProfileRepository.DeactivateUser(userId);
+                    }
                 }
                 else
                 {
@@ -132,6 +144,7 @@ namespace TabloidMVC.Controllers
                 // If something goes wrong, just keep the user on the same page so they can try again
                 return View(userProfile);
             }
+
         }
     }
 }

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -114,9 +114,10 @@ namespace TabloidMVC.Controllers
         {
 
             userId = userProfile.Id;
+            userProfile= _UserProfileRepository.GetUserById(userId);
             List<UserProfile> userProfiles = _UserProfileRepository.GetAllUsers();
-            int totalAdmins = userProfiles.Where(up => up.UserTypeId == 2).Count();
 
+            int totalAdmins = userProfiles.Where(up => up.UserTypeId == 2).Count();
             try
             {
 
@@ -124,8 +125,8 @@ namespace TabloidMVC.Controllers
                 {
                     if (userProfile.UserTypeId == 2 && totalAdmins < 2)
                     {
-                        ModelState.AddModelError("UserTypeId", "Make someone else an admin before this User Profile can be deactivated");
-                        return View();
+                        ModelState.AddModelError("UserTypeId","Assign another admin before deactivating the final admin");
+                        return View(userProfile);
                     }
                     else
                     {

--- a/TabloidMVC/Models/ViewModels/UPEditViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/UPEditViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TabloidMVC.Models.ViewModels
+{
+    public class UPEditViewModel
+    {
+        public UserProfile UserProfile { get; set; }
+        public List<UserType> UserTypes { get; set; }
+    }
+}

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -181,6 +181,27 @@ namespace TabloidMVC.Repositories
             }
         }
 
+        public void ChangeUserType(UserProfile userProfile)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        UPDATE USERPROFILE 
+                            SET UserTypeId = @UserTypeId
+                            WHERE Id = @id"
+                            ;
+                    cmd.Parameters.AddWithValue("@UserTypeId", userProfile.UserTypeId);
+                    cmd.Parameters.AddWithValue("@id", userProfile.Id);
+
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
         public void DeactivateUser(int userId)
         {
             using (var conn = Connection)

--- a/TabloidMVC/Repositories/UserTypeRepository.cs
+++ b/TabloidMVC/Repositories/UserTypeRepository.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
+using TabloidMVC.Models;
+using TabloidMVC.Utils;
+
+namespace TabloidMVC.Repositories
+{
+    public class UserTypeRepository : BaseRepository
+    {
+        public UserTypeRepository(IConfiguration config) : base(config) { }
+
+        public List<UserType> GetAllUserTypes()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT id, Name
+                         FROM UserType";
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    List<UserType> userTypes = new List<UserType>();
+                    while (reader.Read())
+                    {
+                        UserType userType = new UserType
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name= reader.GetString(reader.GetOrdinal("Name"))
+                          
+                        };
+                        userTypes.Add(userType);
+                    }
+
+
+                    reader.Close();
+
+                    return userTypes;
+                }
+            }
+        }
+    }
+}

--- a/TabloidMVC/Views/Comment/Edit.cshtml
+++ b/TabloidMVC/Views/Comment/Edit.cshtml
@@ -29,7 +29,7 @@
     </div>
     <div class="row justify-content-center">
         <a asp-controller="Comment" asp-route-id="@Model.Comment.PostId" asp-action="Index">Back to List</a>
-    </>
+    </div>
 
         @section Scripts {
             @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/TabloidMVC/Views/UserProfile/DeactivateUser.cshtml
+++ b/TabloidMVC/Views/UserProfile/DeactivateUser.cshtml
@@ -46,8 +46,14 @@
                 <dt class="col-sm-2">
                     @Html.DisplayNameFor(model => model.UserType.Name)
                 </dt>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.UserType.Name)
+                </dt>
                 <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.UserType.Name)
+                    @Html.DisplayFor(model => model.UserTypeId)
+                </dd>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.UserTypeId)
                 </dd>
                 <dt class="col-sm-2">
                     Activation Status:
@@ -61,23 +67,27 @@
                 <dd class="col-sm-10">
                     @Html.DisplayFor(model => model.FullName)
                 </dd>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.UserTypeId)
+                </dd>
             </dl>
             @if (Model.Activated == true)
             {
 
-                <form asp-action="DeactivateUser">
-                    <input type="hidden" asp-for="Activated" />
-                    <input type="submit" value="Deactivate User" class="btn btn-danger" /> |
-                    <a asp-action="Index">Back to List</a>
-                </form>
+        <form asp-action="DeactivateUser">
+            <input type="hidden" asp-for="Activated" />
+            @*<input type="hidden" asp-for="UserTypeId" />*@
+            <input type="submit" value="Deactivate User" class="btn btn-danger" /> |
+            <a asp-action="Index">Back to List</a>
+        </form>
             }
             else
             {
-                <form asp-action="DeactivateUser">
-                    <input type="hidden" asp-for="Activated" />
-                    <input type="submit" value="Reactivate User" class="btn btn-danger" /> |
-                    <a asp-action="Index">Back to List</a>
-                </form>
+        <form asp-action="DeactivateUser">
+            <input type="hidden" asp-for="Activated" />
+            <input type="submit" value="Reactivate User" class="btn btn-danger" /> |
+            <a asp-action="Index">Back to List</a>
+        </form>
             }
 
         </div>

--- a/TabloidMVC/Views/UserProfile/DeactivateUser.cshtml
+++ b/TabloidMVC/Views/UserProfile/DeactivateUser.cshtml
@@ -17,79 +17,79 @@
 
             <h3>Are you sure you want to reactivate this user?</h3>
         }
-        <div>
-            <dl class="row">
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.DisplayName)
-                </dt>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.DisplayName)
-                </dd>
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.Email)
-                </dt>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.Email)
-                </dd>
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.CreateDateTime)
-                </dt>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.CreateDateTime)
-                </dd>
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.ImageLocation)
-                </dt>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.ImageLocation)
-                </dd>
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.UserType.Name)
-                </dt>
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.UserType.Name)
-                </dt>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.UserTypeId)
-                </dd>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.UserTypeId)
-                </dd>
-                <dt class="col-sm-2">
-                    Activation Status:
-                </dt>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.Activated)
-                </dd>
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.FullName)
-                </dt>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.FullName)
-                </dd>
-                <dd class="col-sm-10">
-                    @Html.DisplayFor(model => model.UserTypeId)
-                </dd>
-            </dl>
-            @if (Model.Activated == true)
-            {
+    <div>
+        <dl class="row">
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.DisplayName)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.DisplayName)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.Email)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Email)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.CreateDateTime)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.CreateDateTime)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.ImageLocation)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.ImageLocation)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.UserType.Name)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.UserType.Name)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.UserTypeId)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.UserTypeId)
+            </dd>
+            <dt class="col-sm-2">
+                Activation Status:
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Activated)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.FullName)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.FullName)
+            </dd>
 
-        <form asp-action="DeactivateUser">
-            <input type="hidden" asp-for="Activated" />
-            @*<input type="hidden" asp-for="UserTypeId" />*@
-            <input type="submit" value="Deactivate User" class="btn btn-danger" /> |
-            <a asp-action="Index">Back to List</a>
-        </form>
-            }
-            else
-            {
-        <form asp-action="DeactivateUser">
-            <input type="hidden" asp-for="Activated" />
-            <input type="submit" value="Reactivate User" class="btn btn-danger" /> |
-            <a asp-action="Index">Back to List</a>
-        </form>
-            }
+        </dl>
+        @if (Model.Activated == true)
+        {
 
+    <form asp-action="DeactivateUser">
+        <input type="hidden" asp-for="Activated" />
+        <input type="hidden" asp-for="UserTypeId" />
+        <div class="text-danger"> @Html.ValidationMessageFor(m => m.UserTypeId)
         </div>
+        <input type="submit" value="Deactivate User" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+        }
+        else
+        {
+    <form asp-action="DeactivateUser">
+        <input type="hidden" asp-for="Activated" />
+        <input type="submit" value="Reactivate User" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+        }
+
+    </div>
     </div>
 

--- a/TabloidMVC/Views/UserProfile/Edit.cshtml
+++ b/TabloidMVC/Views/UserProfile/Edit.cshtml
@@ -1,0 +1,45 @@
+﻿@model TabloidMVC.Models.ViewModels.UPEditViewModel
+
+
+@{
+    ViewData["Title"] = "Edit";
+}
+
+}
+<div class="container pt-5">
+    <div class="row justify-content-center">
+        <div class="card col-md-12 col-lg-8">
+            <h3 class="mt-3 text-primary text-center card-title">UserProfile : @Model.UserProfile.FullName</h3>
+            <form asp-action="Edit">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group">
+                    <label asp-for="UserProfile.UserTypeId" class="control-label">
+                    </label>
+
+                    <select asp-for="UserProfile.UserTypeId" class="form-control">
+                        @foreach (var userType in Model.UserTypes)
+                        {
+                            <option value="@userType.Id">@userType.Name</option>
+                        }
+                    </select>
+                    <span asp-validation-for="UserProfile.UserTypeId" class="text-danger"></span>
+                </div>
+                <div class="text-danger">
+                </div>
+                <div class="form-group">
+                    <input type="submit" value="Save" class="btn btn-primary" />
+                </div>
+                <div>
+                    <a asp-action="Index">Back to List</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+
+
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}


### PR DESCRIPTION
**Check to see if the following works:**
**ticket 27**
As an admin I would like to be able to change a User Profile's user type so that I can promote people to admin users and demote people to authors.

Given the user is viewing the User Profile list
When they select the option to edit an User Profile
Then the user should be directed to a form and given the ability to change the User Profile's user type.

Given the user is finished updating the User Profile information
When they click the Save button
Then the updated User Profile should be saved to the database
And the user should be redirected to the new User Profile list page.

Given the user has decided not to edit the User Profile
When they click the Cancel button
And the user should be redirected to the new User Profile list page.

**ticket 28**

Given only one User Profile has administrative rights
When the user attempts to deactivate that last admain
Then they should see an error message instructing them to make someone else an admin before the User Profile can be deactivated

Given only one User Profile has administrative rights
When the user attempts to change the User Type of the last admin
Then they should see an error message instructing them to make someone else an admin before the User Profile can be changed